### PR TITLE
Fix infinite loop when handling invisible text

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -29,6 +29,7 @@ func lex(text string) iter.Seq[node] {
 					// NOTE Failed to parse control, so falling back to treating as an invisible
 					// character.
 					n = invisible(text[0:1])
+					rem = rem[1:]
 				}
 				if !yield(n) {
 					return


### PR DESCRIPTION
Parsing unknown (invisible) text would not advance the position, causing the same text to be parsed infinitely.
