### PR TITLE
Fix transparent pixels on short lines

### DIFF
--- a/art.go
+++ b/art.go
@@ -66,6 +66,9 @@ func (a art) asImage() image.Image {
 				panic("unreachable")
 			}
 		}
+		for ; x < a.width; x++ {
+			background.Set(x, y, bgColor)
+		}
 	}
 
 	draw.Draw(background, rect, foreground, image.Point{X: 0, Y: 0}, draw.Over)


### PR DESCRIPTION
When some lines on the ASCII art are shorter than others, the shorter lines would have unset pixels. This continues setting the background from the end of the line to the max X of the image.